### PR TITLE
improve rss reader (close #19)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: paperboy
 Title: Comprehensive Collection of News Media Scrapers
 Version: 0.0.6.9000
-Date: 2024-05-31
+Date: 2024-07-13
 Authors@R:
     person(given = "Johannes B.",
            family = "Gruber",

--- a/R/collect.R
+++ b/R/collect.R
@@ -102,6 +102,8 @@ pb_collect <- function(urls,
 
   if (nrow(out) > 0) {
 
+    class(out$content_raw) <- "html_content"
+
     out <- tibble::add_column(
       out,
       domain = adaR::ada_get_domain(out$expanded_url),
@@ -122,7 +124,7 @@ pb_collect <- function(urls,
         if (verbose) cli::cli_progress_step("Parsing RSS feeds")
         cont <- cont[rss]
         class(cont) <- "html_content"
-        rss_links <- pb_collect_rss(cont)
+        rss_links <- pb_collect_rss(cont)$link
         rss_out <- pb_collect(
           rss_links,
           collect_rss = FALSE,
@@ -148,7 +150,6 @@ pb_collect <- function(urls,
   if (verbose) cli::cli_progress_done()
   attr(out, "paperboy_collected_at") <- Sys.time()
   attr(out, "paperboy_data_loc") <- ifelse(is.null(save_dir), "memory", "disk")
-
   return(out)
 }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -118,7 +118,7 @@ normalise_df <- function(l) {
 
 
 #' base R version of stringi::stri_replace_all() to limit dependencies
-#' @noRd
+#' @keywords internal
 replace_all <- function(str, pattern, replacement, fixed = TRUE) {
   for (i in seq_along(pattern)) str <- gsub(pattern[i], replacement[i], str, fixed = fixed)
   return(str)
@@ -129,6 +129,15 @@ replace_all <- function(str, pattern, replacement, fixed = TRUE) {
 #' @keywords internal
 extract <- function(str, pattern) {
   regmatches(str, regexpr(pattern, str, perl = TRUE))
+}
+
+
+#' replace names of an object given a lookuptable
+#' @keywords internal
+replace_names <- function(x, lookup) {
+  replacement <- lookup[names(x)]
+  names(x) <- ifelse(is.na(replacement), names(x), replacement)
+  return(x)
 }
 
 

--- a/man/pb_collect_rss.Rd
+++ b/man/pb_collect_rss.Rd
@@ -4,21 +4,25 @@
 \alias{pb_collect_rss}
 \title{Collect RSS feed}
 \usage{
-pb_collect_rss(x, ...)
+pb_collect_rss(x, parse = TRUE, ...)
 }
 \arguments{
 \item{x}{URL(s) to RSS or Atom feed(s).}
 
+\item{parse}{Whether the results should be parsed into a data.frame. Turn off for debugging.}
+
 \item{...}{passed to pb_collect.}
 }
 \value{
-a character vector of URLs to articles
+a data.frame or list
 }
 \description{
-Collect the URLs of articles from RSS or Atom feed(s)
+Collect articles from RSS or Atom feed(s)
 }
 \examples{
 \dontrun{
-pb_collect_rss("https://feeds.washingtonpost.com/rss/world")
+pb_collect_rss("https://www.washingtonpost.com/arcio/rss/")
+# works with atom feeds too
+pb_collect_rss("https://www.nu.nl/rss")
 }
 }

--- a/tests/testthat/test-collect.R
+++ b/tests/testthat/test-collect.R
@@ -20,7 +20,7 @@ test_that("expandurls", {
   )
   expect_warning(
     pb_collect(urls = "https://httpbin.org/delay/10", timeout = 1, ignore_fails = TRUE),
-    "download did not finish before timeout."
+    "download.did.not.finish.before.timeout."
   )
 })
 
@@ -28,17 +28,10 @@ test_that("send cookies", {
   jar <- options(cookie_dir = tempdir())
   withr::defer(options(jar))
   withr::defer(unlink(file.path(tempdir(), paste0("cookies.rds"))))
-  expect_equal({
+  expect_equivalent({
     cookiemonster::add_cookies(cookiestring = "test=true; success=yes", domain = "https://hb.cran.dev", confirm = TRUE)
-    pb_collect("https://hb.cran.dev/cookies", use_cookies = TRUE, verbose = FALSE)$content_raw
+    unclass(pb_collect("https://hb.cran.dev/cookies", use_cookies = TRUE, verbose = FALSE)$content_raw)
   }, "{\n  \"cookies\": {\n    \"success\": \"yes\", \n    \"test\": \"true\"\n  }\n}\n")
-})
-
-test_that("rss", {
-  expect_equal({
-    res <- pb_collect(urls = "https://rss.nytimes.com/services/xml/rss/nyt/World.xml")
-    c(nrow(res) > 1, ncol(res))
-  }, c(1, 5))
 })
 
 test_that("store local", {

--- a/tests/testthat/test-rss.R
+++ b/tests/testthat/test-rss.R
@@ -1,0 +1,21 @@
+test_that("rss is collected", {
+  nyt <- pb_collect_rss("https://rss.nytimes.com/services/xml/rss/nyt/HomePage.xml")
+  expect_s3_class(
+    nyt,
+    "data.frame"
+  )
+  expect_more_than(
+    nrow(nyt),
+    0
+  )
+  expect_equal({
+    c(nrow(nyt) > 1, c("title", "link", "published") %in% colnames(nyt))
+  }, rep(TRUE, 4))
+})
+
+test_that("rss is expanded", {
+  expect_equal({
+    res <- pb_collect(urls = "https://rss.nytimes.com/services/xml/rss/nyt/World.xml")
+    c(nrow(res) > 1, ncol(res))
+  }, c(1, 5))
+})


### PR DESCRIPTION
fixes #19 

Currently collects all fields from an RSS feed, which creates a bit of a mess as outlets publish a wide variety of info on their feeds. But the baseline "title", "link", "published" seem always present.

I chose to rename the fields according to the atom convention, to make the two standards equal.