### PR TITLE
Fix pb_available() to recognize hyphenated domains

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -27,7 +27,8 @@ pb_available <- function(...) {
   dots <- unlist(list(...), recursive = TRUE)
 
   if (length(dots) > 0) {
-    return(unlist(sapply(dots, function(x) url_get_domain(x) %in% parsers,
+    return(unlist(sapply(dots, function(x) url_get_domain(x) %>%
+                           gsub("-", ".", ., fixed = TRUE) %in% parsers,
                          simplify = FALSE, USE.NAMES = TRUE)))
   }
 


### PR DESCRIPTION
pb_available() previously did not recognize domains containing hyphens (e.g. augsburger-allgemeine.de), causing them to be incorrectly flagged as unsupported. This PR adds a conversion step that replaces - with . before matching against the list of available parsers.