### PR TITLE
fix: repair broken parsers and add time.com

### DIFF
--- a/R/deliver_bild_de.R
+++ b/R/deliver_bild_de.R
@@ -20,10 +20,21 @@ pb_deliver_paper.bild_de <- function(x, verbose = NULL, pb, ...) {
 
     # author
     author <- meta$author
+    if (is.null(author) || !nzchar(author)) {
+        # documentType "video" etc. carry no author in pageContext; fall back to JSON-LD
+        ld_author <- html %>%
+            rvest::html_element("script[type='application/ld+json']") %>%
+            rvest::html_text() %>%
+            jsonlite::fromJSON() %>%
+            purrr::pluck("author", 1, "name", .default = NA_character_)
+        author <- ld_author
+    }
+    author <- toString(author)
 
     # text
-    text <- html %>%
-        rvest::html_elements(".article-body") %>%
+    text_nodes <- rvest::html_elements(html, ".article-body p")
+    if (length(text_nodes) == 0) text_nodes <- rvest::html_elements(html, "p")
+    text <- text_nodes %>%
         rvest::html_text() %>%
         paste(collapse = "\n")
 

--- a/R/deliver_irishtimes_com.R
+++ b/R/deliver_irishtimes_com.R
@@ -45,7 +45,7 @@ pb_deliver_paper.irishtimes_com <- function(x, verbose = NULL, pb, ...) {
     headline <- data$headline[1]
 
     # author
-    author <- data$author[1]$name %>%
+    author <- data$author[[1]]$name %>%
       toString()
 
     # text

--- a/R/deliver_joe_ie.R
+++ b/R/deliver_joe_ie.R
@@ -7,32 +7,39 @@ pb_deliver_paper.joe_ie <- function(x, verbose = NULL, pb, ...) {
   # raw html is stored in column content_raw
   html <- rvest::read_html(x$content_raw)
 
-  data <- html %>%
-    rvest::html_element("[type=\"application/ld+json\"]") %>%
-    rvest::html_text2()
+  ld <- html %>%
+    rvest::html_elements("[type=\"application/ld+json\"]") %>%
+    rvest::html_text2() %>%
+    lapply(jsonlite::fromJSON)
 
-  if (!isTRUE(is.na(data))) {
-    data <- jsonlite::fromJSON(data)
+  graph <- purrr::detect(ld, function(d) {
+    "NewsArticle" %in% purrr::pluck(d, "@graph", "@type", .default = character(0))
+  })$`@graph`
+
+  if (!is.null(graph)) {
+    article <- graph[graph[["@type"]] == "NewsArticle", ][1, ]
+
     # datetime
-    datetime <- data$datePublished %>%
+    datetime <- article$datePublished %>%
       lubridate::as_datetime()
 
     # headline
-    headline <- data$headline
+    headline <- article$headline
 
     # author
-    author <- data$author$name %>%
+    author_id <- article$author$`@id`[1]
+    author <- graph[["name"]][graph[["@id"]] == author_id] %>%
       toString()
 
     # text
     text <- html %>%
-      rvest::html_elements("article p") %>%
-      rvest::html_text2() %>%
+      html_search(c(".custom-prose p", "p"), attributes = "text", all = FALSE, n = Inf) %>%
       paste(collapse = "\n")
 
-    cover_image_url <- utils::head(data$image$url, 1L)
+    image_id <- article$image$`@id`[1]
+    cover_image_url <- utils::head(graph[["url"]][graph[["@id"]] == image_id], 1L)
 
-    type <- data$`@type`
+    type <- article$`@type`
 
     s_n_list(
       datetime,

--- a/R/deliver_nw_de.R
+++ b/R/deliver_nw_de.R
@@ -14,7 +14,9 @@ pb_deliver_paper.nw_de <- function(x, verbose = NULL, pb, ...) {
         headline <- json_df$headline
         author <- xml2::xml_text(xml2::read_html(
           paste0("<x>", toString(json_df$author$name), "</x>")))
-        text <- json_df$articleBody
+        text <- json_df$articleBody %>%
+          gsub("\\\\n", "\n", .) %>%
+          gsub("\\\\/", "/", .)
         
         # date and time URL was accessed
         accessed <- Sys.time()

--- a/R/deliver_thueringer_allgemeine_de.R
+++ b/R/deliver_thueringer_allgemeine_de.R
@@ -17,6 +17,11 @@ pb_deliver_paper.thueringer_allgemeine_de <- function(x, verbose = NULL, pb, ...
             rvest::html_elements(".article-body p, .article-body h3") %>%
             rvest::html_text2() %>%
             paste(collapse = "\n")
+        if (!nzchar(text)) {
+            text <- html %>%
+                rvest::html_element("[property=\"og:description\"]") %>%
+                rvest::html_attr("content")
+        }
 
         s_n_list(
             datetime,

--- a/R/deliver_time_com.R
+++ b/R/deliver_time_com.R
@@ -1,0 +1,49 @@
+#' @export
+pb_deliver_paper.time_com <- function(x, verbose = NULL, pb, ...) {
+
+  # updates progress bar
+  pb_tick(x, verbose, pb)
+
+  # raw html is stored in column content_raw
+  html <- rvest::read_html(x$content_raw)
+
+  # datetime
+  datetime <- html %>%
+    rvest::html_element("meta[name=\"article:published_time\"]") %>%
+    rvest::html_attr("content") %>%
+    lubridate::as_datetime()
+
+  # headline
+  headline <- html %>%
+    rvest::html_element("meta[property=\"og:title\"]") %>%
+    rvest::html_attr("content")
+
+  # author
+  author <- html %>%
+    rvest::html_element("meta[name=\"author\"]")  %>%
+    rvest::html_attr("content")
+  if (is.na(author)) {
+    author <- html %>%
+      rvest::html_element("[type=\"application/ld+json\"]") %>%
+      rvest::html_text() %>%
+      jsonlite::fromJSON() %>%
+      purrr::pluck("creator", 1, .default = NA_character_)
+  }
+  author <- toString(author)
+
+  # text
+  text <- html %>%
+    rvest::html_elements("article p") %>%
+    rvest::html_text2()
+  text <- text[nzchar(text) & text != "Advertisement"] %>%
+    paste(collapse = "\n")
+
+  # the helper function safely creates a named list from objects
+  s_n_list(
+    datetime,
+    author,
+    headline,
+    text
+  )
+
+}

--- a/inst/status.csv
+++ b/inst/status.csv
@@ -109,7 +109,7 @@
 "noz.de","![](https://img.shields.io/badge/status-gold-%23ffd700.svg)","[@schochastics](https://github.com/schochastics)","[#23](https://github.com/JBGruber/paperboy/issues/23)","https://noz.de/rss"
 "nrc.nl","![](https://img.shields.io/badge/status-gold-%23ffd700.svg)","[@JBGruber](https://github.com/JBGruber/)","","https://nrc.nl/rss"
 "nu.nl","![](https://img.shields.io/badge/status-gold-%23ffd700.svg)","[@JBGruber](https://github.com/JBGruber/)","","https://www.nu.nl/rss"
-"nw.de","![](https://img.shields.io/badge/status-gold-%23ffd700.svg)","[@schochastics](https://github.com/schochastics)","[#23](https://github.com/JBGruber/paperboy/issues/23)","https://nw.de/index.rss"
+"nw.de","![](https://img.shields.io/badge/status-gold-%23ffd700.svg)","[@schochastics](https://github.com/schochastics)","[#23](https://github.com/JBGruber/paperboy/issues/23)","https://www.nw.de/_export/site_rss/nw/index.rss"
 "nypost.com","![](https://img.shields.io/badge/status-gold-%23ffd700.svg)","[@JBGruber](https://github.com/JBGruber/)","","https://nypost.com/?feed=rss2"
 "nytimes.com","![](https://img.shields.io/badge/status-silver-%23C0C0C0.svg)","[@JBGruber](https://github.com/JBGruber/)","[#17](https://github.com/JBGruber/paperboy/issues/17)","https://rss.nytimes.com/services/xml/rss/nyt/HomePage.xml"
 "nzz.ch","![](https://img.shields.io/badge/status-gold-%23ffd700.svg)","[@schochastics](https://github.com/schochastics)","[#23](https://github.com/JBGruber/paperboy/issues/23)","https://www.nzz.ch/recent.rss"

--- a/inst/status.csv
+++ b/inst/status.csv
@@ -98,7 +98,7 @@
 "msnbc.com","![](https://img.shields.io/badge/status-requested-lightgrey)","","[#1](https://github.com/JBGruber/paperboy/issues/1)","https://msnbc.com/feed"
 "n-tv.de","![](https://img.shields.io/badge/status-gold-%23ffd700.svg)","[@schochastics](https://github.com/schochastics)","[#23](https://github.com/JBGruber/paperboy/issues/23)","https://www.n-tv.de/rss"
 "ndr.de","![](https://img.shields.io/badge/status-gold-%23ffd700.svg)","[@schochastics](https://github.com/schochastics)","[#23](https://github.com/JBGruber/paperboy/issues/23)","http://www.ndr.de/home/index-rss.xml"
-"news-und-nachrichten.de","![](https://img.shields.io/badge/status-gold-%23ffd700.svg)","[@schochastics](https://github.com/schochastics)","[#23](https://github.com/JBGruber/paperboy/issues/23)","https://news-und-nachrichten.de/?feed=rss2"
+"news-und-nachrichten.de","![](https://img.shields.io/badge/status-shutdown-red.svg)","[@schochastics](https://github.com/schochastics)","[#23](https://github.com/JBGruber/paperboy/issues/23)","https://news-und-nachrichten.de/?feed=rss2"
 "news.de","![](https://img.shields.io/badge/status-gold-%23ffd700.svg)","[@schochastics](https://github.com/schochastics)","[#23](https://github.com/JBGruber/paperboy/issues/23)","https://www.news.de/rss/364367598/politik/"
 "newsflash24.de","![](https://img.shields.io/badge/status-gold-%23ffd700.svg)","[@schochastics](https://github.com/schochastics)","[#23](https://github.com/JBGruber/paperboy/issues/23)","https://newsflash24.de/?feed=rss2"
 "newstatesman.com","![](https://img.shields.io/badge/status-gold-%23ffd700.svg)","[@JBGruber](https://github.com/JBGruber/)","","https://www.newstatesman.com/feed/"

--- a/inst/status.csv
+++ b/inst/status.csv
@@ -163,7 +163,7 @@
 "thelily.com","![](https://img.shields.io/badge/status-requested-lightgrey)","","[#1](https://github.com/JBGruber/paperboy/issues/1)",NA
 "thesun.ie","![](https://img.shields.io/badge/status-gold-%23ffd700.svg)","[@JBGruber](https://github.com/JBGruber/)","","https://www.thesun.ie/feed/"
 "thueringer-allgemeine.de","![](https://img.shields.io/badge/status-gold-%23ffd700.svg)","[@schochastics](https://github.com/schochastics)","[#23](https://github.com/JBGruber/paperboy/issues/23)","https://www.thueringer-allgemeine.de/rss"
-"time.com","![](https://img.shields.io/badge/status-requested-lightgrey)","","[#1](https://github.com/JBGruber/paperboy/issues/1)","https://time.com/data/rss"
+"time.com","![](https://img.shields.io/badge/status-gold-%23ffd700.svg)","","[#1](https://github.com/JBGruber/paperboy/issues/1)","https://time.com/feed"
 "tribpub.com","![](https://img.shields.io/badge/status-requested-lightgrey)","","[#1](https://github.com/JBGruber/paperboy/issues/1)","https://tribpub.com/rss"
 "tz.de","![](https://img.shields.io/badge/status-gold-%23ffd700.svg)","[@schochastics](https://github.com/schochastics)","[#23](https://github.com/JBGruber/paperboy/issues/23)","https://www.tz.de/welt/rssfeed.rdf"
 "us.cnn.com","![](https://img.shields.io/badge/status-gold-%23ffd700.svg)","[@JBGruber](https://github.com/JBGruber/)","","http://rss.cnn.com/rss/cnn_allpolitics.rss"


### PR DESCRIPTION
Repairs several broken/degraded parsers flagged by the health monitor, plus one new site.

## Fixed
- **bild.de** — `author` fallback added for video-type pages with no personal byline; cleaned up `text` (was picking up skip-link UI and stray hydration-comment artifacts).
- **irishtimes.com** — `author` extraction was structurally broken (wrong list-indexing always returned `NULL`); fixed.
- **joe.ie** — page now emits two JSON-LD blocks; parser was reading the wrong one. Also fixed `text`, which was pulling in shared sidebar content.
- **nw.de** — recorded RSS feed was a stale 2014 dump; replaced with the live feed. Fixed a double-escaping bug leaving literal `\n`/`\/` in article text.
- **thueringer-allgemeine.de** — added an `og:description` fallback for paywalled articles with no body text. `status.csv` left unchanged: the real blocker is a WAF User-Agent block with no field to record the fix.

## Added
- **time.com** — new parser, with a JSON-LD fallback for profile pages with no individual byline.

## Not fixed (flagged, no changes)
- **derstandard.at** — `datetime`/`author` withheld behind a cookie-consent wall, not in the static HTML.
- **newstatesman.com** — parser is fine, but every feed URL is WAF-blocked; sitemaps work but aren't feed-parseable.
- **news-und-nachrichten.de** — domain no longer resolves (DNS failure); marked "shutdown" in `status.csv`.
