### PR TITLE
Add cnnbrasil.com.br parser

### DIFF
--- a/R/deliver_cnnbrasil_com_br.R
+++ b/R/deliver_cnnbrasil_com_br.R
@@ -1,0 +1,30 @@
+#' @export
+pb_deliver_paper.cnnbrasil_com_br <- function(x, verbose = NULL, pb, ...) {
+
+  # updates progress bar
+  pb_tick(x, verbose, pb)
+
+  # raw html is stored in column content_raw
+  html <- rvest::read_html(x$content_raw)
+
+  # The best version of the text and metadata is in a JSON-LD block
+  json_txt <- rvest::html_elements(html, "script[id ^= \"schema-api\"]") %>%
+    rvest::html_text()
+  if (length(json_txt) == 0) return(s_n_list())
+
+  json_df <- jsonlite::fromJSON(json_txt[[1]])[["@graph"]] |>
+    dplyr::filter(`@type` == "NewsArticle")
+  if (is.null(json_df) || nrow(json_df) != 1) return(s_n_list())
+
+  datetime <- lubridate::as_datetime(json_df$datePublished)
+  author <- toString(json_df$author$name)
+  headline <- json_df$headline
+  text <- trimws(gsub("<[^>]+>", "", json_df$articleBody))
+
+  s_n_list(
+    datetime,
+    author,
+    headline,
+    text
+  )
+}

--- a/R/deliver_cnnbrasil_com_br.R
+++ b/R/deliver_cnnbrasil_com_br.R
@@ -1,0 +1,34 @@
+#' @export
+pb_deliver_paper.cnnbrasil_com_br <- function(x, verbose = NULL, pb, ...) {
+
+  # updates progress bar
+  pb_tick(x, verbose, pb)
+
+  # raw html is stored in column content_raw
+  html <- rvest::read_html(x$content_raw)
+
+  # The best version of the text and metadata is in a JSON-LD block
+  json_txt <- rvest::html_elements(html, "script[id ^= \"schema-api\"]") %>%
+    rvest::html_text()
+  if (length(json_txt) == 0) return(s_n_list())
+
+  # If there's a straightforward NewsArticle entry this is our best choice.
+  # Recently, articles have had their metadata embedded a layer deep in a graph
+  # data block instead.
+  json_df <- jsonlite::fromJSON(json_txt[[1]])[["@graph"]] |>
+    dplyr::filter(`@type` == "NewsArticle")
+
+  if (is.null(json_df)) return(s_n_list())
+
+  datetime <- lubridate::as_datetime(json_df$datePublished)
+  author <- toString(json_df$author$name)
+  headline <- json_df$headline
+  text <- trimws(gsub("<[^>]+>", "", json_df$articleBody))
+
+  s_n_list(
+    datetime,
+    author,
+    headline,
+    text
+  )
+}

--- a/inst/status.csv
+++ b/inst/status.csv
@@ -28,6 +28,7 @@
 "ceskatelevize.cz","![](https://img.shields.io/badge/status-gold-%23ffd700.svg)","[@JBGruber](https://github.com/JBGruber/)","","https://ct24.ceskatelevize.cz/rss"
 "cnet.com","![](https://img.shields.io/badge/status-gold-%23ffd700.svg)","[@JBGruber](https://github.com/JBGruber/)","","https://www.cnet.com/rss/news/"
 "cnn.com","![](https://img.shields.io/badge/status-gold-%23ffd700.svg)","[@JBGruber](https://github.com/JBGruber/)","","http://rss.cnn.com/rss/cnn_latest.rss"
+"cnnbrasil.com.br","![](https://img.shields.io/badge/status-gold-%23ffd700.svg)","[@pmyteh](https://github.com/pmyteh/)","","https://cnnbrasil.com.br/feed"
 "courier-journal.com","![](https://img.shields.io/badge/status-gold-%23ffd700.svg)","[@JBGruber](https://github.com/JBGruber/)","",NA
 "dailymail.co.uk","![](https://img.shields.io/badge/status-gold-%23ffd700.svg)","[@JBGruber](https://github.com/JBGruber/)","","https://www.dailymail.co.uk/news/index.rss"
 "decider.com","![](https://img.shields.io/badge/status-gold-%23ffd700.svg)","LLM agent","","https://decider.com/?feed=rss"


### PR DESCRIPTION
This is the first in what I hope will be a series of new parsers for Brazilian news sources, to support the [INEQNEWS](https://cordis.europa.eu/project/id/101077310) project. It handles content from CNN Brasil.

I've tried to follow the instructions in the [developers' page](https://jbgruber.github.io/paperboy/articles/For_Developers.html) closely, but if there are issues now would be an excellent time to know about them!

Thanks,
Tom